### PR TITLE
Feature/question has multiple topics and quizzes

### DIFF
--- a/src/actions/questions.js
+++ b/src/actions/questions.js
@@ -1,9 +1,14 @@
 import * as types from '../constants/actionTypes';
 
-export function addQuestion() {
-  return {type: types.ADD_QUESTION, data: {
-    answer: 1,
-    options: ['{', '[', '*', '-'],
-    question: 'What marks an array in javascript?',
-  }};
+export function addQuestion(topicId, questionId) {
+  return {
+    type: types.ADD_QUESTION,
+    data: {
+      id: questionId,
+      answer: 1,
+      options: ['{', '[', '*', '-'],
+      question: 'What marks an array in javascript?',
+    },
+    topicId,
+  };
 }

--- a/src/components/question.js
+++ b/src/components/question.js
@@ -14,7 +14,7 @@ class Question extends React.Component {
       question,
     } = this.props;
     return (
-      <div class="question">
+      <div className="question">
         <p>{question}</p>
         <ul>{options.map((option, index) => (
             <li key={index} className={index === answer ? 'correct' : ''}>{option}</li>

--- a/src/components/questionList.js
+++ b/src/components/questionList.js
@@ -6,11 +6,19 @@ import {addQuestion} from '../actions/questions';
 
 class QuestionList extends React.Component {
   render() {
+    const {
+      topicId,
+      questions,
+    } = this.props;
+
+    // TODO: get a guaranteed uniqe Id from somewhere
+    var questionId = Math.round(Math.random() * 1000);
+
     return (
       <div className="question-list">
         <ul>
         {
-          this.props.questions.map(question => (
+          questions.map(question => (
             <li>
             <Question {...question}/>
             <a>Delete</a>
@@ -18,14 +26,13 @@ class QuestionList extends React.Component {
           ))
         }
         </ul>
-        <a onClick={this.props.addQuestion}>Create New Question</a>
+        <a onClick={() => this.props.addQuestion(topicId, questionId)}>Create New Question</a>
       </div>
     );
   }
 }
 
 export default connect(state => ({
-  questions: state.questions.data
 }), {
   addQuestion
 })(QuestionList)

--- a/src/components/quiz.js
+++ b/src/components/quiz.js
@@ -1,18 +1,33 @@
 import React from 'react';
 // import {Link} from 'react-router';
-// import {connect} from 'react-redux';
+import {connect} from 'react-redux';
 import Topic from './topic';
+
+// Get as route param from react-router
+const id = 1;
 
 class Quiz extends React.Component {
   render() {
+    const {
+      quiz: {
+        name,
+        topics,
+      },
+    } = this.props;
+
     return (
       <div className="quiz">
-        <h1> Quiz 123465 </h1>
-        <Topic/>
-        <Topic/>
+        <h1>{name}</h1>
+        {topics.map(topicId => <Topic id={topicId} />)}
       </div>
     );
   }
 }
 
-export default Quiz;
+export default connect(state => {
+  const quiz = state.quizzes.find(quiz => quiz.id === id);
+
+  return {
+    quiz,
+  };
+}, {})(Quiz);

--- a/src/components/topic.js
+++ b/src/components/topic.js
@@ -1,18 +1,31 @@
 import React from 'react';
-// import {Link} from 'react-router';
-// import {connect} from 'react-redux';
+import {connect} from 'react-redux';
 import QuestionList from './questionList';
 
 class Topic extends React.Component {
   render() {
+    const {
+      id,
+      name,
+      questions,
+    } = this.props;
+
     return (
       <div className="topic">
-        <h2> Algebra </h2>
+        <h2>{name}</h2>
         <a>Set PreRequisite</a>
-        <QuestionList/>
+        <QuestionList topicId={id} questions={questions}/>
       </div>
     );
   }
 }
 
-export default Topic;
+export default connect((state, ownProps) => {
+  const topic = state.topics.find(topic => topic.id === ownProps.id);
+  const questions = state.questions.filter(question => topic.questions.includes(question.id));
+
+  return {
+    topic,
+    questions
+  };
+}, {})(Topic);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,9 +1,13 @@
 import { combineReducers } from 'redux';
 import questions from './questions';
+import quizzes from './quizzes';
+import topics from './topics';
 import {routerReducer} from 'react-router-redux';
 
 const rootReducer = combineReducers({
   questions,
+  quizzes,
+  topics,
   routing: routerReducer
 });
 

--- a/src/reducers/initialState.js
+++ b/src/reducers/initialState.js
@@ -24,7 +24,7 @@ export default {
 				'questions': {
 					'data': [
 						{
-							'answer': '2',
+							'answer': 2,
 							'options': [
 								'sin(A) + sin(B)',
 								'sin(A) + cos(B)',

--- a/src/reducers/initialState.js
+++ b/src/reducers/initialState.js
@@ -1,42 +1,53 @@
 export default {
-	// 'quiz': {
-	// 'topics': [
-	// 	{
-	// 		'algebra': {
-	// 			'description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas eu efficitur risus. Donec porta eget elit vitae porttitor. In hac habitasse platea dictumst. Etiam dapibus rutrum nisl. Aliquam egestas sapien nec ipsum accumsan, quis placerat ante accumsan. Duis sed lectus nec purus sagittis cursus. Duis ultrices sodales arcu, pulvinar imperdiet nunc fringilla condimentum. Ut risus velit, mollis in nisi nec, elementum tempus diam. In sagittis sapien ac arcu pharetra faucibus. Nunc eget sapien eu justo volutpat efficitur. Integer convallis magna eget diam pulvinar, sit amet condimentum felis euismod. Proin at mattis arcu. Cras faucibus tortor scelerisque purus tempor, id interdum leo dictum.',
-	// 			'questions': {
-	// 				'data': [
-	// 					{
-	// 						'answer': '1',
-	// 						'options': [
-	// 							'{',
-	// 							'[',
-	// 							'*',
-	// 							'-'
-	// 						],
-	// 						'question': 'What marks an array in javascript?'
-	// 					}
-	// 				]
-	// 			}
-	// 		},
-	// 		'geometry': {
-	// 			'description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas eu efficitur risus. Donec porta eget elit vitae porttitor. In hac habitasse platea dictumst. Etiam dapibus rutrum nisl. Aliquam egestas sapien nec ipsum accumsan, quis placerat ante accumsan. Duis sed lectus nec purus sagittis cursus. Duis ultrices sodales arcu, pulvinar imperdiet nunc fringilla condimentum. Ut risus velit, mollis in nisi nec, elementum tempus diam. In sagittis sapien ac arcu pharetra faucibus. Nunc eget sapien eu justo volutpat efficitur. Integer convallis magna eget diam pulvinar, sit amet condimentum felis euismod. Proin at mattis arcu. Cras faucibus tortor scelerisque purus tempor, id interdum leo dictum.',
-				'questions': {
-					'data': [
-						{
-							'answer': 2,
-							'options': [
-								'sin(A) + sin(B)',
-								'sin(A) + cos(B)',
-								'cos(A)sin(B)',
-								'sin(A)sin(B)'
-							],
-							'question': 'What is sin(A+B)?'
-						}
-					]
-				}
-	// 		}
-	// 	}
-	// ]
-	// }
+  topics: [{
+    id: 1,
+    name: 'Algebra',
+    questions: [1, 2],
+  }, {
+    id: 2,
+    name: 'Geography',
+    questions: [],
+  }, {
+    id: 3,
+    name: 'Common Sense',
+    questions: [3],
+  }],
+
+  quizzes: [{
+    id: 1,
+    name: 'My first Quiz',
+    topics: [1, 3]
+  }],
+
+	questions: [{
+    id: 1,
+		answer: 2,
+		options: [
+			'sin(A) + sin(B)',
+			'sin(A) + cos(B)',
+			'cos(A)sin(B)',
+			'sin(A)sin(B)'
+		],
+		question: 'What is sin(A+B)?'
+	}, {
+    id: 2,
+    answer: 0,
+    options: [
+      '0',
+      '3',
+      '5',
+      '15'
+    ],
+    question: 'What is (6 - (2 * 2)) * 3 * 5?'
+  }, {
+    id: 3,
+    answer: 0,
+    options: [
+      '0',
+      '3',
+      '42',
+      '15'
+    ],
+    question: 'What is the one answer?'
+  }]
 };

--- a/src/reducers/quizzes.js
+++ b/src/reducers/quizzes.js
@@ -1,13 +1,8 @@
 import {ADD_QUESTION} from '../constants/actionTypes';
 import initialState from './initialState';
 
-export default function questions(state = initialState.questions, action) {
+export default function questions(state = initialState.quizzes, action) {
   switch (action.type) {
-    case ADD_QUESTION:
-      return [
-        ...state,
-        action.data
-      ];
 
     default:
       return state;

--- a/src/reducers/topics.js
+++ b/src/reducers/topics.js
@@ -1,0 +1,25 @@
+import {ADD_QUESTION} from '../constants/actionTypes';
+import initialState from './initialState';
+
+export default function questions(state = initialState.topics, action) {
+  let unchangedTopics;
+  let changedTopic;
+
+  switch (action.type) {
+
+    case ADD_QUESTION:
+      unchangedTopics = state.filter(topic => action.topicId !== topic.id);
+      changedTopic = state.find(topic => action.topicId === topic.id);
+
+      return [
+        ...unchangedTopics,
+        {
+          ...changedTopic,
+          questions: [...changedTopic.questions, action.data.id],
+        }
+      ];
+
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
This is the alternative to #3 as it provides a more "database-like" view on the world. The advantages are

- you may easier get access to a specific question or question set by naming their quiz / topic / id
- it is more flexible and has only one level of data structure, so there are no update problems
- it is nearer to an API you might want to support

The disadvantages are

- You need to acces multiple reducers to access the data you want (see topic / questionList's connect statements)